### PR TITLE
feat(rd_pipe_plugin): cooperative cancellation (#57)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,13 @@ features = [
     "net",
     "parking_lot",
     "io-util",
-    "time"
+    "time",
+    "macros",
 ]
+
+[dependencies.tokio-util]
+version = "0.7"
+default-features = false
 
 [dev-dependencies]
 libloading = "0.8"

--- a/src/rd_pipe_plugin.rs
+++ b/src/rd_pipe_plugin.rs
@@ -230,8 +230,7 @@ impl RdPipeChannelCallback {
         writer: Arc<Mutex<Option<WriteHalf<NamedPipeServer>>>>,
         channel_agile: AgileReference<IWTSVirtualChannel>,
         pipe_addr: String,
-        // Task 4: rename to `shutdown` and capture in async block
-        _shutdown: CancellationToken,
+        shutdown: CancellationToken,
     ) {
         ASYNC_RUNTIME.spawn(async move {
             let mut first_pipe_instance = true;
@@ -270,13 +269,28 @@ impl RdPipeChannelCallback {
                     Ok(s) => s,
                     Err(e) => {
                         error!("Error while creating named pipe server: {}", e);
-                        sleep(Duration::from_millis(100)).await;
+                        tokio::select! {
+                            biased;
+                            _ = shutdown.cancelled() => {
+                                trace!("Shutdown signalled during pipe-server creation retry");
+                                break;
+                            }
+                            _ = sleep(Duration::from_millis(100)) => {}
+                        }
                         continue;
                     }
                 };
                 first_pipe_instance = false;
                 trace!("Initiate connection to pipe client");
-                match server.connect().await {
+                let connect_res = tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => {
+                        trace!("Shutdown signalled while awaiting pipe client connection");
+                        break;
+                    }
+                    res = server.connect() => res,
+                };
+                match connect_res {
                     Ok(_) => {
                         let channel = match channel_agile.resolve() {
                             Ok(channel) => channel,
@@ -302,7 +316,27 @@ impl RdPipeChannelCallback {
                 trace!("Pipe client connected. Initiating pipe_reader loop");
                 'reader: loop {
                     let mut buf = Vec::with_capacity(64 * 1024);
-                    match server_reader.read_buf(&mut buf).await {
+                    let read_res = tokio::select! {
+                        biased;
+                        _ = shutdown.cancelled() => {
+                            trace!("Shutdown signalled inside reader loop");
+                            match channel_agile.resolve() {
+                                Ok(channel) => match unsafe { channel.Write(&[MSG_XOFF], None) } {
+                                    Ok(_) => trace!("Wrote XOFF to channel on shutdown"),
+                                    Err(e) => error!("Error writing XOFF on shutdown: {}", e),
+                                },
+                                Err(e) => {
+                                    error!(
+                                        "Failed to resolve agile reference for channel on shutdown: {}",
+                                        e
+                                    );
+                                }
+                            }
+                            break 'reader;
+                        }
+                        res = server_reader.read_buf(&mut buf) => res,
+                    };
+                    match read_res {
                         Ok(0) => {
                             info!("Received 0 bytes, pipe closed by client");
                             let channel = match channel_agile.resolve() {

--- a/src/rd_pipe_plugin.rs
+++ b/src/rd_pipe_plugin.rs
@@ -20,9 +20,9 @@ use std::{io::ErrorKind::WouldBlock, sync::Arc};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt, WriteHalf, split},
     net::windows::named_pipe::{NamedPipeServer, ServerOptions},
-    task::JoinHandle,
     time::{Duration, sleep},
 };
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
 use windows::Win32::Foundation::{ERROR_PIPE_NOT_CONNECTED, HLOCAL};
 use windows::{
@@ -200,7 +200,7 @@ const MSG_XOFF: u8 = 0x13;
 #[implement(IWTSVirtualChannelCallback)]
 pub struct RdPipeChannelCallback {
     pipe_writer: Arc<Mutex<Option<WriteHalf<NamedPipeServer>>>>,
-    join_handle: JoinHandle<()>,
+    shutdown: CancellationToken,
 }
 
 impl RdPipeChannelCallback {
@@ -214,11 +214,14 @@ impl RdPipeChannelCallback {
         );
         let channel_agile = AgileReference::new(channel)?;
         let pipe_writer = Arc::new(Mutex::new(None));
+        let shutdown = CancellationToken::new();
         debug!("Constructing the callback");
 
+        Self::process_pipe(pipe_writer.clone(), channel_agile, addr, shutdown.clone());
+
         Ok(Self {
-            pipe_writer: pipe_writer.clone(),
-            join_handle: Self::process_pipe(pipe_writer, channel_agile, addr),
+            pipe_writer,
+            shutdown,
         })
     }
 
@@ -227,7 +230,9 @@ impl RdPipeChannelCallback {
         writer: Arc<Mutex<Option<WriteHalf<NamedPipeServer>>>>,
         channel_agile: AgileReference<IWTSVirtualChannel>,
         pipe_addr: String,
-    ) -> JoinHandle<()> {
+        // Task 4: rename to `shutdown` and capture in async block
+        _shutdown: CancellationToken,
+    ) {
         ASYNC_RUNTIME.spawn(async move {
             let mut first_pipe_instance = true;
             let login_sid = match get_logon_sid() {
@@ -361,7 +366,7 @@ impl RdPipeChannelCallback {
                 }
                 trace!("Writer released");
             }
-        })
+        });
     }
 }
 
@@ -369,6 +374,7 @@ impl fmt::Debug for RdPipeChannelCallback_Impl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RdPipeChannelCallback_Impl")
             .field("pipe_writer", &self.pipe_writer)
+            .field("shutdown_cancelled", &self.shutdown.is_cancelled())
             .finish()
     }
 }
@@ -398,13 +404,11 @@ impl IWTSVirtualChannelCallback_Impl for RdPipeChannelCallback_Impl {
 
     #[instrument]
     fn OnClose(&self) -> Result<()> {
+        self.shutdown.cancel();
         let mut writer_guard = self.pipe_writer.lock();
         if let Some(ref mut writer) = *writer_guard {
             ASYNC_RUNTIME.block_on(writer.shutdown())?;
             *writer_guard = None;
-        }
-        if !self.join_handle.is_finished() {
-            self.join_handle.abort();
         }
         Ok(())
     }

--- a/tests/dvc_emulation.rs
+++ b/tests/dvc_emulation.rs
@@ -410,9 +410,9 @@ fn multiple_channels_produce_multiple_listeners() {
 
 /// Regression test for issue #57: `OnClose` must terminate the reader task
 /// while the client is still connected and any subsequent `OnDataReceived`
-/// must fail with `ERROR_PIPE_NOT_CONNECTED`. Today the shutdown is driven
-/// by dropping the write half inside `OnClose`; after Task 4 it will also
-/// be driven cooperatively via `CancellationToken` + `tokio::select!`.
+/// must fail with `ERROR_PIPE_NOT_CONNECTED`. Shutdown is driven cooperatively
+/// via `CancellationToken` + `tokio::select!`, with `OnClose` synchronously
+/// dropping the write half so this assertion holds without polling.
 #[test]
 #[serial]
 fn on_close_terminates_reader_cooperatively_while_client_connected() {

--- a/tests/dvc_emulation.rs
+++ b/tests/dvc_emulation.rs
@@ -407,3 +407,62 @@ fn multiple_channels_produce_multiple_listeners() {
 
     drop(plugin);
 }
+
+/// Regression test for issue #57: `OnClose` must terminate the reader task
+/// while the client is still connected and any subsequent `OnDataReceived`
+/// must fail with `ERROR_PIPE_NOT_CONNECTED`. Today the shutdown is driven
+/// by dropping the write half inside `OnClose`; after Task 4 it will also
+/// be driven cooperatively via `CancellationToken` + `tokio::select!`.
+#[test]
+#[serial]
+fn on_close_terminates_reader_cooperatively_while_client_connected() {
+    let hkcu = common::HkcuOverride::new().expect("override hkcu");
+    hkcu.write_channel_names(&["RdPipeTest"])
+        .expect("write channel names");
+
+    let dll = common::DllHandle::load();
+    let plugin = common::create_plugin(dll);
+
+    let (mgr_iface, mgr_state) = common::FakeChannelMgr::new();
+    unsafe {
+        plugin.Initialize(&mgr_iface).expect("Initialize");
+    }
+
+    let listener_cb = get_listener_cb(&mgr_state, "RdPipeTest");
+    let (channel_iface, chan_state) = common::FakeVirtualChannel::new();
+    let chan_cb = common::trigger_new_channel(&listener_cb, &channel_iface);
+    let addr = common::channel_addr(&channel_iface);
+
+    common::block_on(async {
+        let _client =
+            common::connect_pipe_client("RdPipeTest", addr, std::time::Duration::from_secs(5))
+                .await;
+
+        // Wait for XON, confirming the pipe connection handshake completed.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while chan_state.snapshot_writes().is_empty() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            !chan_state.snapshot_writes().is_empty(),
+            "timed out waiting for XON"
+        );
+
+        // Cooperative shutdown: OnClose while the client is still connected.
+        unsafe { chan_cb.OnClose().expect("OnClose") };
+
+        // Subsequent OnDataReceived must fail with ERROR_PIPE_NOT_CONNECTED
+        // (writer released synchronously by OnClose).
+        let r = unsafe { chan_cb.OnDataReceived(b"\xab") };
+        assert!(
+            matches!(
+                r,
+                Err(ref e) if e.code() == windows::Win32::Foundation::ERROR_PIPE_NOT_CONNECTED.into()
+            ),
+            "expected ERROR_PIPE_NOT_CONNECTED after OnClose, got {:?}",
+            r
+        );
+    });
+
+    drop(plugin);
+}


### PR DESCRIPTION
## Summary

- Replace `JoinHandle::abort()` shutdown of the pipe-reader task with cooperative cancellation via `tokio_util::sync::CancellationToken` and `tokio::select!`.
- Each `RdPipeChannelCallback` owns a `CancellationToken`. `OnClose` calls `cancel()` (latched), then drops the writer. The reader task races every `.await` (`server.connect()`, retry `sleep`, `read_buf`) against `shutdown.cancelled()` with `biased;` so cancel always wins ties.
- On cooperative shutdown inside the reader, the cancel arm best-effort emits `MSG_XOFF` to the channel before exiting.

Closes #57.

## Why `CancellationToken` + `select!`

- **Latched semantics** — once cancelled, every subsequent `cancelled().await` resolves immediately. `Notify` would lose signals fired between awaits during synchronous work (mutex / COM `Write` / `AgileReference::resolve`).
- **Composable** — `child_token()` allows a future plugin-level shutdown tree.
- **Idiomatic** — matches tokio's documented graceful-shutdown pattern.
- `select!` keeps shutdown observation at single, well-defined points without forced task abort.

## Changes

- `Cargo.toml` — add `macros` feature to prod `tokio`; add `tokio-util = "0.7"` (`default-features = false`).
- `src/rd_pipe_plugin.rs` — replace `join_handle: JoinHandle<()>` with `shutdown: CancellationToken`; constructor creates token, clones into spawned (detached) task; three `tokio::select! { biased; ... }` blocks in `process_pipe`; `OnClose` calls `cancel()` first; `Debug` exposes `shutdown_cancelled`.
- `tests/dvc_emulation.rs` — new regression test `on_close_terminates_reader_cooperatively_while_client_connected` asserting `OnClose` while the client is still connected releases the writer and a follow-up `OnDataReceived` fails with `ERROR_PIPE_NOT_CONNECTED`.

## Commits

1. `deps: add tokio macros feature and tokio-util for cooperative cancellation`
2. `refactor(rd_pipe_plugin): swap JoinHandle for CancellationToken` (behaviour-preserving)
3. `test(dvc_emulation): cooperative OnClose while client connected`
4. `feat(rd_pipe_plugin): cooperative cancellation via tokio::select! and CancellationToken`
5. `test(dvc_emulation): refresh doc comment after cooperative cancellation merged`

## Out of scope

- Plugin-level cancellation tree via `child_token()`.
- Awaiting task completion in `OnClose` (`block_on(JoinHandle)` from a COM callback risks deadlock).
- Pre-existing fall-through after `server.connect()` `Err` arm — filed as #60.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo test` — 32 unit + 5 dll_smoke + 10 dvc_emulation, all pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New regression test `on_close_terminates_reader_cooperatively_while_client_connected` passes

Spec: `docs/superpowers/specs/2026-04-30-cooperative-cancellation-design.md` (kept locally; not in repo)
Plan: `docs/superpowers/plans/2026-04-30-cooperative-cancellation-plan.md` (kept locally; not in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)