### PR TITLE
ci: run tests via nextest with JUnit + PR annotations

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# Nextest profile used by CI.
+# Emits JUnit XML at target/nextest/ci/junit.xml for action-junit-report.
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "30s", terminate-after = 2 }
+
+[profile.ci.junit]
+path = "junit.xml"
+report-name = "rd_pipe"
+store-success-output = false
+store-failure-output = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,27 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Build cdylib
         run: cargo build --target ${{ matrix.target }}
 
       - name: Run tests
-        run: cargo test --target ${{ matrix.target }}
+        run: cargo nextest run --target ${{ matrix.target }} --profile ci
+
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          report_paths: 'target/nextest/ci/junit.xml'
+          check_name: 'Tests (${{ matrix.target }})'
+          detailed_summary: true
+          include_passed: false
+          annotate_only: false
+          require_tests: true
 
   build:
     name: Build

--- a/TESTING.md
+++ b/TESTING.md
@@ -91,6 +91,17 @@ The tests **will work correctly** on Windows with proper Visual Studio toolchain
 cargo test
 ```
 
+CI uses [`cargo-nextest`](https://nexte.st/) for structured JUnit output and
+parallel execution. To match CI locally:
+
+```bash
+cargo install cargo-nextest --locked
+cargo build --target x86_64-pc-windows-msvc
+cargo nextest run --target x86_64-pc-windows-msvc --profile ci
+```
+
+This emits `target/nextest/ci/junit.xml` consumed by the CI report step.
+
 ### Run Tests for Specific Module
 ```bash
 cargo test --lib registry
@@ -188,11 +199,15 @@ mod tests {
 
 ## CI/CD Integration
 
-The CI pipeline now includes a dedicated test job that:
-1. Runs on Windows Server 2025
-2. Uses x86_64-pc-windows-msvc target
-3. Executes all unit tests
-4. Fails the build if any tests fail
+The CI pipeline runs tests across all four Windows MSVC targets
+(`i686`, `x86_64`, `aarch64`, `arm64ec`) using `cargo-nextest` with the
+`ci` profile defined in `.config/nextest.toml`. JUnit XML output is
+consumed by `mikepenz/action-junit-report@v5`, which:
+
+1. Publishes a per-target check run named `Tests (<target>)`.
+2. Annotates failing tests inline on the PR diff (file + line).
+3. Writes a detailed pass/fail summary table to the workflow run's
+   Summary tab via `$GITHUB_STEP_SUMMARY`.
 
 Tests run automatically on:
 - Pull requests to master branch


### PR DESCRIPTION
## Summary
- Swap `cargo test` for `cargo nextest run --profile ci` in the test matrix
- Add `.config/nextest.toml` defining the `ci` profile that emits `target/nextest/ci/junit.xml`
- Publish report via `mikepenz/action-junit-report@v5` — inline PR annotations on failures + detailed summary table per matrix target on workflow run page

## Test plan
- [x] Local: `cargo nextest run --target aarch64-pc-windows-msvc --profile ci` — 47/47 pass in 1.063s, valid JUnit XML emitted
- [ ] CI: confirm 4 matrix targets each produce `Tests (<target>)` check run with summary
- [ ] CI: induce a test failure in a follow-up to verify annotation rendering on PR diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)