### PR TITLE
Fix arm64x

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - windows-11-arm
+
+config-variables: null
+
+paths:

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   labels:
     - windows-11-arm
+    - windows-2025-vs2026
 
 config-variables: null
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
       - name: cargo fmt -- --check
         run: cargo fmt --all -- --check
@@ -72,7 +72,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -128,7 +128,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -179,7 +179,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
           components: llvm-tools
 
       - name: Build merged ARM64X DLL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: beta
           components: rustfmt
       - name: cargo fmt -- --check
         run: cargo fmt --all -- --check
@@ -72,7 +72,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: beta
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -128,7 +128,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: beta
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -179,7 +179,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: beta
           components: llvm-tools
 
       - name: Build merged ARM64X DLL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: beta
+          toolchain: nightly
           components: rustfmt
       - name: cargo fmt -- --check
         run: cargo fmt --all -- --check
@@ -45,26 +45,32 @@ jobs:
             target: i686-pc-windows-msvc
             runner: windows-2025
             artifact: rd_pipe-x86
+            toolchain: stable
           - name: x64
             target: x86_64-pc-windows-msvc
             runner: windows-2025
             artifact: rd_pipe-x64
+            toolchain: stable
           - name: arm64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
             artifact: rd_pipe-arm64
+            toolchain: nightly
           - name: arm64ec
             target: arm64ec-pc-windows-msvc
             runner: windows-11-arm
             artifact: rd_pipe-arm64ec
+            toolchain: nightly
           - name: arm64x-on-arm64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
             artifact: rd_pipe-arm64x
+            toolchain: nightly
           - name: arm64x-on-arm64ec
             target: arm64ec-pc-windows-msvc
             runner: windows-11-arm
             artifact: rd_pipe-arm64x
+            toolchain: nightly
 
     steps:
       - uses: actions/checkout@v6
@@ -72,7 +78,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: beta
+          toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -115,12 +121,16 @@ jobs:
         include:
           - target: i686-pc-windows-msvc
             suffix: x86
+            toolchain: stable
           - target: x86_64-pc-windows-msvc
             suffix: x64
+            toolchain: stable
           - target: aarch64-pc-windows-msvc
             suffix: arm64
+            toolchain: nightly
           - target: arm64ec-pc-windows-msvc
             suffix: arm64ec
+            toolchain: nightly
 
     steps:
       - uses: actions/checkout@v6
@@ -128,7 +138,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: beta
+          toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -179,7 +189,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: beta
+          toolchain: nightly
           components: llvm-tools
 
       - name: Build merged ARM64X DLL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: stable
           components: rustfmt
       - name: cargo fmt -- --check
         run: cargo fmt --all -- --check
@@ -43,12 +43,12 @@ jobs:
         include:
           - name: x86
             target: i686-pc-windows-msvc
-            runner: windows-2025
+            runner: windows-2025-vs2026
             artifact: rd_pipe-x86
             toolchain: stable
           - name: x64
             target: x86_64-pc-windows-msvc
-            runner: windows-2025
+            runner: windows-2025-vs2026
             artifact: rd_pipe-x64
             toolchain: stable
           - name: arm64
@@ -114,7 +114,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +170,7 @@ jobs:
   build-arm64x:
     name: Build ARM64X merged DLL
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,16 @@ jobs:
           toolchain: nightly
           components: llvm-tools
 
+      # Windows SDK >= 10.0.28000 is required: older SDKs make the ARM64X
+      # link pull msvcrt.lib's vcstartup glue, producing a DLL that crashes
+      # at load. See arm64x/build_merged.ps1 for details.
+      - name: Install Windows SDK 10.0.28000
+        shell: pwsh
+        run: |
+          winget install --id Microsoft.WindowsSDK.10.0.28000 --source winget `
+            --accept-package-agreements --accept-source-agreements `
+            --disable-interactivity --silent
+
       - name: Build merged ARM64X DLL
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: llvm-tools
 
       - name: Build merged ARM64X DLL
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,10 @@ jobs:
           name: rd_pipe-arm64ec
           path: artifacts/arm64ec
 
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Set up VS Developer Command Prompt (arm64)
+        uses: ilammy/msvc-dev-cmd@v1
         with:
-          toolchain: nightly
+          arch: arm64
 
       - name: Build merged ARM64X DLL
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,16 +192,6 @@ jobs:
           toolchain: nightly
           components: llvm-tools
 
-      # Windows SDK >= 10.0.28000 is required: older SDKs make the ARM64X
-      # link pull msvcrt.lib's vcstartup glue, producing a DLL that crashes
-      # at load. See arm64x/build_merged.ps1 for details.
-      - name: Install Windows SDK 10.0.28000
-        shell: pwsh
-        run: |
-          winget install --id Microsoft.WindowsSDK.10.0.28000 --source winget `
-            --accept-package-agreements --accept-source-agreements `
-            --disable-interactivity --silent
-
       - name: Build merged ARM64X DLL
         shell: pwsh
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,23 @@ CI matrix targets: `i686`, `x86_64`, `aarch64`, `arm64ec` — all `*-pc-windows-
 
 ## ARM64X merged DLL (`arm64x/build_merged.ps1`)
 
-The `aarch64` + `arm64ec` staticlibs are linked into one ARM64X (hybrid) DLL by `arm64x/build_merged.ps1`, using `rust-lld` (`/machine:arm64x`) and `llvm-readobj` from the active rustc toolchain (needs the `llvm-tools` component). Per-arch export tables are generated on the fly from each DLL via `llvm-readobj --coff-exports`.
+The `aarch64` + `arm64ec` staticlibs are linked into one ARM64X (hybrid) DLL by `arm64x/build_merged.ps1`, using **MSVC link.exe** (`/machine:arm64x`, discovered via vswhere) and `llvm-readobj` from the active rustc toolchain (needs the `llvm-tools` component). Per-arch export tables are generated on the fly from each DLL via `llvm-readobj --coff-exports`.
 
-Two hard requirements, both learned the hard way:
+**Why MSVC link.exe, not rust-lld (`lld-link.exe`)**: lld corrupts the EC view's TLS directory (`_tls_used`/`_tls_index`/TLS-callback table) when merging two full Rust staticlibs into one ARM64X image, causing `fatal runtime error: the System allocator may not use TLS with destructors` (0xc0000409) on the EC view at test time. MSVC link.exe handles the ARM64X TLS merge correctly.
+
+One hard requirement:
 
 - **Toolchain must be `nightly`.** `arm64ec` staticlibs built on stable/beta crash at `0xc0000096` when an ARM64X DLL is loaded from an x64 process on ARM64 Windows (rust-lang/rust#145154). Fixed by #148799 (TLS dtors → FLS), first in nightly `1.98.0` (2026-06-03). The `Test (arm64x-on-arm64ec)` job is the gate; it only runs on the `windows-11-arm` runner.
-- **Windows SDK >= 10.0.28000 on the linking runner.** With SDK 10.0.26100 the linker pulls `msvcrt.lib`'s vcstartup glue (`utility.obj`), which references static-only `__vcrt_initialize` / `__acrt_initialize` and fails the link. Pulling in the static `libvcruntime`/`libucrt` makes it link but double-initialises the CRT → merged DLL crashes at load (`0xc0000005`). SDK >= 28000 doesn't pull `utility.obj`, so a **dynamic-CRT-only** link (kernel32/msvcrt/ucrt/vcruntime import libs, both arches by full path, no ambient `LIB`) is correct and runtime-safe. `Get-SdkLibRoot` enforces the version; the `build-arm64x` CI job installs it via `winget`.
 
-The script can be exercised on a Windows ARM64 host: build both staticlibs+DLLs (`cargo +nightly build --release --target {aarch64,arm64ec}-pc-windows-msvc`), run the script with `$env:LIB=''`, then validate the merged DLL with `RD_PIPE_DLL_PATH=<dll> cargo +nightly nextest run --target aarch64-pc-windows-msvc -E 'binary(dll_smoke) or binary(dvc_emulation)'`.
+Link recipe (dynamic CRT, MSVC link.exe):
+- Both per-arch staticlibs as explicit inputs (`rd_pipe.lib` arm64 + arm64ec)
+- `arm64\vcruntime.lib` + `arm64\msvcrt.lib` (arm64 MSVC CRT libs serve both views; arm64\msvcrt.lib provides `__icall_helper_arm64ec` for the EC view's raw_dylib import stubs)
+- `um\arm64\{kernel32,ntdll,userenv,ws2_32,dbghelp}` + `um\x64\{same}` + `um\x64\softintrin.lib`
+- `/LIBPATH:` for MSVC arm64+x64 and SDK ucrt/um arm64+x64 dirs (resolves `.drectve /defaultlib:` entries without vcvars)
+- `/force:multiple` resolves duplicate `DllMain` (arm64 + arm64ec each define it, plus msvcrt's stub); msvcrt's stub wins but correctly chains through `_pRawDllMain` → user DllMain
+- No SDK version constraint (both 26100 and 28000 work)
+
+The script can be exercised on a Windows ARM64 host: build both staticlibs+DLLs (`cargo +nightly build --release --target {aarch64,arm64ec}-pc-windows-msvc`), run the script, then validate the merged DLL with `RD_PIPE_DLL_PATH=<dll> cargo +nightly nextest run --target {aarch64,arm64ec}-pc-windows-msvc -E 'binary(dll_smoke) or binary(dvc_emulation)'`.
 
 ## Registration (DllInstall)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,17 @@ cargo fmt --all -- --check                         # CI style check
 
 CI matrix targets: `i686`, `x86_64`, `aarch64`, `arm64ec` — all `*-pc-windows-msvc`. Citrix registration code (`ctx_*`) is `#[cfg(target_arch = "x86")]` only.
 
+## ARM64X merged DLL (`arm64x/build_merged.ps1`)
+
+The `aarch64` + `arm64ec` staticlibs are linked into one ARM64X (hybrid) DLL by `arm64x/build_merged.ps1`, using `rust-lld` (`/machine:arm64x`) and `llvm-readobj` from the active rustc toolchain (needs the `llvm-tools` component). Per-arch export tables are generated on the fly from each DLL via `llvm-readobj --coff-exports`.
+
+Two hard requirements, both learned the hard way:
+
+- **Toolchain must be `nightly`.** `arm64ec` staticlibs built on stable/beta crash at `0xc0000096` when an ARM64X DLL is loaded from an x64 process on ARM64 Windows (rust-lang/rust#145154). Fixed by #148799 (TLS dtors → FLS), first in nightly `1.98.0` (2026-06-03). The `Test (arm64x-on-arm64ec)` job is the gate; it only runs on the `windows-11-arm` runner.
+- **Windows SDK >= 10.0.28000 on the linking runner.** With SDK 10.0.26100 the linker pulls `msvcrt.lib`'s vcstartup glue (`utility.obj`), which references static-only `__vcrt_initialize` / `__acrt_initialize` and fails the link. Pulling in the static `libvcruntime`/`libucrt` makes it link but double-initialises the CRT → merged DLL crashes at load (`0xc0000005`). SDK >= 28000 doesn't pull `utility.obj`, so a **dynamic-CRT-only** link (kernel32/msvcrt/ucrt/vcruntime import libs, both arches by full path, no ambient `LIB`) is correct and runtime-safe. `Get-SdkLibRoot` enforces the version; the `build-arm64x` CI job installs it via `winget`.
+
+The script can be exercised on a Windows ARM64 host: build both staticlibs+DLLs (`cargo +nightly build --release --target {aarch64,arm64ec}-pc-windows-msvc`), run the script with `$env:LIB=''`, then validate the merged DLL with `RD_PIPE_DLL_PATH=<dll> cargo +nightly nextest run --target aarch64-pc-windows-msvc -E 'binary(dll_smoke) or binary(dvc_emulation)'`.
+
 ## Registration (DllInstall)
 
 `regsvr32 /i:"<flags> <ChannelName1> <ChannelName2> ..." rd_pipe.dll` drives registration via `DllInstall`. Flag chars parsed from arg[0]:

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -7,22 +7,17 @@
 #   -Arm64ecDll : path to target\arm64ec-pc-windows-msvc\release\rd_pipe.dll
 #   -OutDir     : directory to place the merged rd_pipe.dll
 #
-# Final link uses /MACHINE:ARM64X via MSVC link.exe (discovered from the
-# active VS installation via vswhere), which handles the ARM64X TLS directory
-# correctly. lld-link is NOT used because it corrupts the EC view's TLS
-# (_tls_used/_tls_index/TLS-callback directory) when merging two full Rust
-# staticlibs.
+# Requires a VS Developer Command Prompt environment (vcvarsall arm64 or the
+# ilammy/msvc-dev-cmd action with arch:arm64). This sets:
+#   PATH              -> link.exe, dumpbin.exe
+#   VCToolsInstallDir -> MSVC lib root
+#   WindowsSdkDir + WindowsSDKVersion -> SDK lib root
+#   LIB               -> arm64 MSVC + arm64 ucrt + arm64 um (native view)
 #
-# Import libs are passed explicitly by full path for both the ARM64 (native)
-# and x64 (EC) views because an /machine:arm64x link needs import libraries
-# for both architectures. Bare lib names resolved from ambient LIB only cover
-# one architecture.
+# Uses MSVC link.exe (/machine:arm64x). lld-link is NOT used: it corrupts the
+# EC view's TLS directory when merging two Rust staticlibs into one ARM64X image.
 #
-# DEF files are generated on the fly from the per-arch DLLs via
-# `dumpbin /exports` (same VS install, no extra components needed) so the
-# merged binary's export table is the exact union of the per-arch tables
-# (DllMain, DllGetClassObject, DllInstall, plus anything Rust adds in the
-# future). Avoids drift between a hand-maintained DEF and what rustc exports.
+# DEF files generated via dumpbin /exports; no llvm-tools component needed.
 
 [CmdletBinding()]
 param(
@@ -35,99 +30,30 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Resolve MSVC link.exe and dumpbin.exe. Both come from the same VS VC tools
-# install — no extra rustup components required.
-# Prefers ARM64-hosted binaries (run natively); falls back to x64-hosted.
-# Uses VCToolsInstallDir env (set by vcvars) or discovers via vswhere.
-function Get-MsvcTool {
-    param([string]$Name)
-    $vcRoot = $null
-    if ($env:VCToolsInstallDir) {
-        $vcRoot = $env:VCToolsInstallDir.TrimEnd('\/')
-    } else {
-        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-        if (-not (Test-Path -LiteralPath $vswhere)) { throw "vswhere.exe not found at $vswhere" }
-        $vsRoot = (& $vswhere -latest -prerelease -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath | Select-Object -First 1)
-        if (-not $vsRoot) { $vsRoot = (& $vswhere -latest -prerelease -products * -property installationPath | Select-Object -First 1) }
-        if (-not $vsRoot) { throw "No Visual Studio with VC tools found via vswhere" }
-        $verFile = Join-Path $vsRoot 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
-        if (-not (Test-Path -LiteralPath $verFile)) { throw "VC tools version file not found at $verFile" }
-        $ver = (Get-Content -LiteralPath $verFile -Raw).Trim()
-        $vcRoot = Join-Path $vsRoot "VC\Tools\MSVC\$ver"
+# Validate vcvars environment.
+foreach ($v in 'VCToolsInstallDir', 'WindowsSdkDir', 'WindowsSDKVersion') {
+    if (-not (Get-Item "Env:$v" -ErrorAction SilentlyContinue)) {
+        throw "$v not set — run inside a VS Developer Command Prompt (vcvarsall arm64)."
     }
-    foreach ($hostDir in 'Hostarm64\arm64', 'HostARM64\arm64', 'Hostx64\x64') {
-        $p = Join-Path $vcRoot "bin\$hostDir\$Name"
-        if (Test-Path -LiteralPath $p) { return $p }
-    }
-    throw "MSVC $Name not found under $vcRoot\bin"
 }
 
-function Get-MsvcLibRoot {
-    # Derive lib root from VCToolsInstallDir or the same vswhere path Get-MsvcTool uses.
-    if ($env:VCToolsInstallDir) {
-        $r = Join-Path $env:VCToolsInstallDir.TrimEnd('\/') 'lib'
-        if (Test-Path -LiteralPath $r) { return (Resolve-Path -LiteralPath $r).Path }
-    }
-    # Get-MsvcTool already validated the VS install; re-derive the lib path from it.
-    $linkExePath = Get-MsvcTool 'link.exe'   # e.g. ...\bin\Hostarm64\arm64\link.exe
-    # Strip \arm64, \Hostarm64, \bin to reach the MSVC version root
-    $vcVersionRoot = Split-Path (Split-Path (Split-Path (Split-Path $linkExePath)))
-    $root = Join-Path $vcVersionRoot 'lib'
-    if (-not (Test-Path -LiteralPath $root)) { throw "MSVC lib root not found at $root" }
-    return $root
-}
+$msvcLib = Join-Path $env:VCToolsInstallDir.TrimEnd('\/') 'lib'
+$sdkLib  = Join-Path $env:WindowsSdkDir.TrimEnd('\/') "Lib\$($env:WindowsSDKVersion.TrimEnd('\/'))"
 
-function Get-SdkLibRoot {
-    $kitsRoot = $null
-    foreach ($hive in 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0',
-                      'HKLM:\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0') {
-        $p = (Get-ItemProperty -Path $hive -Name 'KitsRoot10' -ErrorAction SilentlyContinue).KitsRoot10
-        if ($p) { $kitsRoot = $p; break }
-    }
-    if (-not $kitsRoot) { $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10' }
-    $libBase = Join-Path $kitsRoot 'Lib'
-    if (-not (Test-Path -LiteralPath $libBase)) { throw "Windows SDK Lib base not found at $libBase" }
-    # Pick the highest-versioned SDK that ships both arm64 and x64 ucrt/um libs.
-    $sdk = Get-ChildItem -LiteralPath $libBase -Directory |
-        Where-Object { (Test-Path (Join-Path $_.FullName 'um\arm64')) -and
-                       (Test-Path (Join-Path $_.FullName 'um\x64')) } |
-        Sort-Object { [version]$_.Name } -Descending |
-        Select-Object -First 1
-    if (-not $sdk) {
-        throw "No Windows SDK with arm64 + x64 um libs found under $libBase."
-    }
-    return $sdk.FullName
-}
+Write-Host "==> MSVC lib root:    $msvcLib"
+Write-Host "==> Windows SDK root: $sdkLib"
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
-$linkExe     = Get-MsvcTool 'link.exe'
-$dumpbinExe  = Get-MsvcTool 'dumpbin.exe'
-$msvcLibRoot = Get-MsvcLibRoot
-$sdkLibRoot  = Get-SdkLibRoot
-
-Write-Host "==> MSVC link.exe:    $linkExe"
-Write-Host "==> MSVC dumpbin.exe: $dumpbinExe"
-Write-Host "==> MSVC lib root:    $msvcLibRoot"
-Write-Host "==> Windows SDK root: $sdkLibRoot"
-
-# Generate a DEF file from a per-arch DLL via `dumpbin /exports`.
-# Output format includes lines like:
-#   <ordinal>  <hint>  <RVA>  <name>
-# We match the name in the 4th field of export lines.
+# Generate a DEF file from a per-arch DLL via dumpbin /exports.
 function New-DefFromDll {
     param([string]$Dll, [string]$DefPath)
-    $names = & $dumpbinExe /exports $Dll 2>&1 |
+    $names = dumpbin /exports $Dll 2>&1 |
         Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
         ForEach-Object { $_.Matches[0].Groups[1].Value }
-    if (-not $names) {
-        throw "No exports found in $Dll via $dumpbinExe"
-    }
-    $lines = @('EXPORTS') + ($names | ForEach-Object { "    $_" })
-    Set-Content -Path $DefPath -Value $lines -Encoding ASCII
-    Write-Host "==> Generated $DefPath ($($names.Count) exports): $($names -join ', ')"
+    if (-not $names) { throw "No exports found in $Dll" }
+    Set-Content -Path $DefPath -Value (@('EXPORTS') + ($names | ForEach-Object { "    $_" })) -Encoding ASCII
+    Write-Host "==> $DefPath ($($names.Count) exports): $($names -join ', ')"
 }
 
 $defArm64   = Join-Path $OutDir 'rd_pipe.arm64.def'
@@ -135,130 +61,56 @@ $defArm64ec = Join-Path $OutDir 'rd_pipe.arm64ec.def'
 New-DefFromDll -Dll $Arm64Dll   -DefPath $defArm64
 New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
 
-# Import libs needed for the /machine:arm64x link.
-# Mirror exactly what rustc passes for each architecture (from `cargo rustc -- --print link-args`):
-#   ARM64 (native view): kernel32 ntdll userenv ws2_32 dbghelp  + /defaultlib:msvcrt
-#   ARM64EC (EC view):   kernel32 ntdll userenv ws2_32 dbghelp  + /defaultlib:msvcrt + softintrin
+# Import libs for the /machine:arm64x link.
 #
-# An ARM64X link has TWO symbol namespaces; we need CRT + SDK libs for BOTH:
-#   - MSVC arm64\ for both views (msvcrt, vcruntime, ucrt-style helpers)
-#   - SDK ucrt\arm64  for the native view
-#   - SDK ucrt\arm64ec (or x64 fallback) for the EC view
-#   - SDK um\arm64    for the native view
-#   - SDK um\arm64ec  (or x64 fallback) for the EC view
-#   - softintrin (EC/arm64ec only)
+# arm64 (native) view: LIB env covers these; passed by bare name.
 #
-# Note: __icall_helper_arm64ec lives in arm64\msvcrt.lib (not x64 or arm64ec).
-# Note: SDK 10.0.28000 does not have a um\arm64ec dir; fall back to um\x64.
-function Resolve-LibForView {
-    param([string]$Name, [string]$Arch)  # Arch = 'arm64' | 'arm64ec'
-    # CRT libs from MSVC: always use arm64 dir (same helpers serve both views)
-    if ($Name -match '^(msvcrt|vcruntime)\.lib$') {
-        $p = Join-Path $msvcLibRoot "arm64\$Name"
-        if (-not (Test-Path -LiteralPath $p)) { throw "MSVC lib not found: $p" }
-        return $p
-    }
-    # SDK ucrt
-    if ($Name -match '^ucrt\.lib$') {
-        foreach ($a in $Arch, 'x64') {
-            $p = Join-Path $sdkLibRoot "ucrt\$a\$Name"
-            if (Test-Path -LiteralPath $p) { return $p }
-        }
-        throw "ucrt.lib not found for arch $Arch"
-    }
-    # SDK um libs (kernel32, ntdll, etc.)
-    foreach ($a in $Arch, 'x64', 'arm64') {
-        $dir = Join-Path $sdkLibRoot "um\$a"
-        if (Test-Path -LiteralPath $dir) {
-            $found = Get-ChildItem $dir -Filter $Name -ErrorAction SilentlyContinue |
-                Select-Object -First 1 -ExpandProperty FullName
-            if ($found) { return $found }
-        }
-    }
-    throw "SDK um lib $Name not found for arch $Arch"
-}
+# arm64ec (EC) view: ARM64EC uses x64 calling convention, so the SDK stores
+#   its import libs under the x64 subdirectory (no separate arm64ec dir).
+#   MSVC CRT helpers (vcruntime, msvcrt) use the arm64 dir — same native
+#   code runs for both views. Passed by full path since LIB is arm64-only.
+#   arm64\msvcrt.lib provides __icall_helper_arm64ec for EC raw_dylib stubs.
+#   softintrin.lib (arm64ec view only) is under SDK um\x64.
+$importLibs = @(
+    # arm64 native view — resolved via LIB env
+    'vcruntime.lib',
+    'kernel32.lib',
+    'ntdll.lib',
+    'userenv.lib',
+    'ws2_32.lib',
+    'dbghelp.lib',
+    # arm64ec view — SDK arm64ec libs live under x64 subdir; MSVC CRT from arm64 dir
+    "$msvcLib\arm64\vcruntime.lib",
+    "$sdkLib\um\x64\kernel32.Lib",
+    "$sdkLib\um\x64\ntdll.lib",
+    "$sdkLib\um\x64\UserEnv.Lib",
+    "$sdkLib\um\x64\WS2_32.Lib",
+    "$sdkLib\um\x64\DbgHelp.Lib",
+    "$sdkLib\um\x64\softintrin.lib"
+)
 
-$crtLibNames = @('vcruntime.lib')
-$umLibNames  = @('kernel32.Lib', 'ntdll.lib', 'UserEnv.Lib', 'WS2_32.Lib', 'DbgHelp.Lib')
-
-$importLibs = @()
-foreach ($name in ($crtLibNames + $umLibNames)) {
-    $importLibs += (Resolve-LibForView -Name $name -Arch 'arm64')
-}
-foreach ($name in ($crtLibNames + $umLibNames)) {
-    $importLibs += (Resolve-LibForView -Name $name -Arch 'arm64ec')
-}
-# softintrin is EC (arm64ec/x64-ABI) only - SDK um x64
-$softintrin = Join-Path $sdkLibRoot 'um\x64\softintrin.lib'
-if (-not (Test-Path -LiteralPath $softintrin)) {
-    $softintrin = Join-Path $sdkLibRoot 'um\arm64\softintrin.lib'
-    if (-not (Test-Path -LiteralPath $softintrin)) { throw "softintrin.lib not found" }
-}
-$importLibs += $softintrin
-
-# arm64\msvcrt.lib provides __icall_helper_arm64ec (needed by EC raw_dylib stubs)
-# but also contains dll_dllmain_stub.obj which would override our DllMain if passed
-# as an explicit input. Pass it via /DEFAULTLIB: so it is lower priority than the
-# explicit staticlibs: our DllMain objects from rd_pipe.lib win, dll_dllmain_stub
-# becomes the second definition (ignored by /force:multiple).
-$msvcrtArm64Lib  = Join-Path $msvcLibRoot 'arm64\msvcrt.lib'
-$msvcrtX64Lib    = Join-Path $msvcLibRoot 'x64\msvcrt.lib'
-if (-not (Test-Path -LiteralPath $msvcrtArm64Lib)) { throw "arm64\msvcrt.lib not found at $msvcrtArm64Lib" }
-if (-not (Test-Path -LiteralPath $msvcrtX64Lib))   { throw "x64\msvcrt.lib not found at $msvcrtX64Lib" }
-
-Write-Host "==> Import libs (arm64 native + arm64ec EC):"
-$importLibs | ForEach-Object { Write-Host "    $_" }
+# msvcrt.lib passed after staticlibs (via /NODEFAULTLIB + explicit path) so
+# the linker processes our DllMain objects first. The msvcrt stub DllMain wins
+# via /force:multiple but correctly chains through _pRawDllMain to our DllMain.
+# arm64\msvcrt.lib serves both views: it provides __icall_helper_arm64ec for
+# the arm64ec raw_dylib stubs as well as the native CRT startup glue.
+$msvcrtLib = "$msvcLib\arm64\msvcrt.lib"
 
 $outDll = Join-Path $OutDir 'rd_pipe.dll'
 
-Write-Host "==> Linking ARM64X merged DLL with MSVC link.exe"
-# /defArm64Native + /def supply the export tables for the ARM64 native and
-# ARM64EC views respectively. Each DEF is generated from the matching
-# per-arch DLL so the merged binary exposes the exact union of exports
-# rustc emitted for each arch.
-#
-# /force:multiple: resolves duplicate DllMain symbols. The merged link has two
-# DllMain definitions: one from each per-arch staticlib AND a stub from
-# msvcrt.lib(dll_dllmain_stub.obj). The stub wins via /force:multiple but that
-# is intentional: the stub is the CRT-wrapped DllMain — it calls
-# dllmain_crt_process_attach which chains through _pRawDllMain to user code.
-# Our actual DllMain (tracing init + Tokio runtime) runs via _pRawDllMain.
-#
-# arm64\msvcrt.lib is passed after the staticlibs via /NODEFAULTLIB + explicit
-# path so the linker sees our DllMain objects before the stub. msvcrt.lib is
-# still needed as an explicit input because arm64\msvcrt.lib provides
-# __icall_helper_arm64ec (used by the EC view's raw_dylib import stubs) and
-# arm64\vcruntime.lib provides __CxxFrameHandler3/__chkstk.
-#
-# /LIBPATH: dirs allow the .drectve /defaultlib:... entries baked into the
-# staticlibs to resolve without vcvars being active.
-$libpathMsvcArm64  = Join-Path $msvcLibRoot 'arm64'
-$libpathMsvcX64    = Join-Path $msvcLibRoot 'x64'
-$libpathUcrtArm64  = Join-Path $sdkLibRoot 'ucrt\arm64'
-$libpathUcrtArm64ec= Join-Path $sdkLibRoot 'ucrt\arm64ec'
-$libpathUcrtX64    = Join-Path $sdkLibRoot 'ucrt\x64'
-$libpathUmArm64    = Join-Path $sdkLibRoot 'um\arm64'
-$libpathUmX64      = Join-Path $sdkLibRoot 'um\x64'
-
-& $linkExe `
-    /dll /machine:arm64x /nologo `
-    /noimplib `
-    /force:multiple `
+Write-Host "==> Linking ARM64X DLL..."
+link.exe `
+    /dll /machine:arm64x /nologo /noimplib /force:multiple `
     "/NODEFAULTLIB:msvcrt" `
-    "/LIBPATH:$libpathMsvcArm64" `
-    "/LIBPATH:$libpathMsvcX64" `
-    "/LIBPATH:$libpathUcrtArm64" `
-    "/LIBPATH:$libpathUcrtArm64ec" `
-    "/LIBPATH:$libpathUcrtX64" `
-    "/LIBPATH:$libpathUmArm64" `
-    "/LIBPATH:$libpathUmX64" `
-    "/defArm64Native:$defArm64" `
-    "/def:$defArm64ec" `
+    "/LIBPATH:$msvcLib\arm64" `
+    "/LIBPATH:$sdkLib\ucrt\arm64" `
+    "/LIBPATH:$sdkLib\um\arm64" `
+    "/LIBPATH:$sdkLib\ucrt\x64" `
+    "/LIBPATH:$sdkLib\um\x64" `
+    "/defArm64Native:$defArm64" "/def:$defArm64ec" `
     "/out:$outDll" `
-    $Arm64Lib $Arm64ecLib `
-    @importLibs `
-    $msvcrtArm64Lib $msvcrtX64Lib
-if ($LASTEXITCODE -ne 0) { throw "MSVC link.exe failed with exit code $LASTEXITCODE" }
+    $Arm64Lib $Arm64ecLib @importLibs $msvcrtLib
+if ($LASTEXITCODE -ne 0) { throw "link.exe failed ($LASTEXITCODE)" }
 
-Write-Host "==> Merged ARM64X DLL built: $outDll"
+Write-Host "==> Built: $outDll"
 Get-Item $outDll | Format-List FullName, Length, LastWriteTime

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -71,13 +71,26 @@ Write-Host "==> link:    $linkExe"
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
 # Generate a DEF file from a per-arch DLL via dumpbin /exports.
+#
+# DllMain is the DLL entry point — it is not a named export and must not appear
+# in the DEF file (causes LNK4006 duplicate-symbol warning against msvcrt's stub).
+#
+# DllGetClassObject and DllInstall are COM/regsvr32 entry points looked up via
+# GetProcAddress; they must be PRIVATE (no import-lib entry) to suppress LNK4104.
+$privateExports = @('DllGetClassObject', 'DllInstall')
+$skipExports    = @('DllMain')
+
 function New-DefFromDll {
     param([string]$Dll, [string]$DefPath)
     $names = & $dumpbinExe /exports $Dll 2>&1 |
         Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
-        ForEach-Object { $_.Matches[0].Groups[1].Value }
+        ForEach-Object { $_.Matches[0].Groups[1].Value } |
+        Where-Object { $_ -notin $skipExports }
     if (-not $names) { throw "No exports found in $Dll" }
-    Set-Content -Path $DefPath -Value (@('EXPORTS') + ($names | ForEach-Object { "    $_" })) -Encoding ASCII
+    $lines = $names | ForEach-Object {
+        if ($_ -in $privateExports) { "    $_ PRIVATE" } else { "    $_" }
+    }
+    Set-Content -Path $DefPath -Value (@('EXPORTS') + $lines) -Encoding ASCII
     Write-Host "==> $DefPath ($($names.Count) exports): $($names -join ', ')"
 }
 
@@ -126,6 +139,7 @@ $outDll = Join-Path $OutDir 'rd_pipe.dll'
 Write-Host "==> Linking ARM64X DLL..."
 & $linkExe `
     /dll /machine:arm64x /nologo /noimplib /force:multiple `
+    "/ignore:4001,4088" `
     "/NODEFAULTLIB:msvcrt" `
     "/LIBPATH:$msvcLib\arm64" `
     "/LIBPATH:$sdkLib\ucrt\arm64" `

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -72,20 +72,15 @@ New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
 # Generate a DEF file from a per-arch DLL via dumpbin /exports.
 #
-# DllMain is the DLL entry point — it is not a named export and must not appear
-# in the DEF file (causes LNK4006 duplicate-symbol warning against msvcrt's stub).
-#
 # DllGetClassObject and DllInstall are COM/regsvr32 entry points looked up via
 # GetProcAddress; they must be PRIVATE (no import-lib entry) to suppress LNK4104.
 $privateExports = @('DllGetClassObject', 'DllInstall')
-$skipExports    = @('DllMain')
 
 function New-DefFromDll {
     param([string]$Dll, [string]$DefPath)
     $names = & $dumpbinExe /exports $Dll 2>&1 |
         Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
-        ForEach-Object { $_.Matches[0].Groups[1].Value } |
-        Where-Object { $_ -notin $skipExports }
+        ForEach-Object { $_.Matches[0].Groups[1].Value }
     if (-not $names) { throw "No exports found in $Dll" }
     $lines = $names | ForEach-Object {
         if ($_ -in $privateExports) { "    $_ PRIVATE" } else { "    $_" }
@@ -139,7 +134,7 @@ $outDll = Join-Path $OutDir 'rd_pipe.dll'
 Write-Host "==> Linking ARM64X DLL..."
 & $linkExe `
     /dll /machine:arm64x /nologo /noimplib /force:multiple `
-    "/ignore:4001,4088" `
+    "/ignore:4001" "/ignore:4006" "/ignore:4088" `
     "/NODEFAULTLIB:msvcrt" `
     "/LIBPATH:$msvcLib\arm64" `
     "/LIBPATH:$sdkLib\ucrt\arm64" `

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -72,29 +72,25 @@ $defArm64ec = Join-Path $OutDir 'rd_pipe.arm64ec.def'
 New-DefFromDll -Dll $Arm64Dll   -DefPath $defArm64
 New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
 
-# Windows SDK / CRT libs needed for the link to succeed:
-# - kernel32.lib     : __chkstk, _tls_index/_tls_used, baseline Win32
-# - msvcrt.lib       : dynamic-CRT import lib; _CxxThrowException,
-#                      __CxxFrameHandler3, and the vcstartup DLL glue
-#                      (utility.obj / _DllMainCRTStartup) that newer
-#                      toolchains pull in.
-# - ucrt.lib         : memcpy/memset/memmove/memcmp, wcslen, etc.
-# - vcruntime.lib    : softintrin / icall helpers (ARM64EC)
-# - libvcruntime.lib : STATIC vcruntime. Defines __vcrt_initialize and the
-#                      __vcrt_* thread attach/detach helpers that
-#                      msvcrt.lib(utility.obj) references but that the
-#                      *dynamic* import libs do not define.
-# - libucrt.lib      : STATIC UCRT. Defines __acrt_initialize,
-#                      _is_c_termination_complete and the __acrt_* helpers,
-#                      likewise referenced by the vcstartup glue.
-# - uuid.lib         : pulled via a /defaultlib directive emitted by the
-#                      libvcruntime objects.
-# msvcrt + the dynamic ucrt/vcruntime are listed before their static
-# counterparts so that, under /force:multiple, the dynamic CRT definitions
-# win and the static libs only supply the otherwise-undefined vcstartup
-# init helpers. All other Win32 imports (advapi32, bcrypt, ntdll, ole32,
-# oleaut32, userenv, ws2_32, synchronization) come in transitively via the
+# Windows SDK / CRT import libs needed for the link to succeed:
+# - kernel32.lib  : __chkstk, _tls_index/_tls_used, baseline Win32
+# - msvcrt.lib    : _CxxThrowException, __CxxFrameHandler3 (ARM64EC)
+# - ucrt.lib      : memcpy/memset/memmove/memcmp, wcslen, etc.
+# - vcruntime.lib : softintrin / icall helpers (ARM64EC)
+# All other Win32 imports (advapi32, bcrypt, ntdll, ole32, oleaut32,
+# userenv, ws2_32, synchronization) are pulled in transitively via the
 # Rust staticlibs' raw_dylib stubs.
+#
+# These are the DYNAMIC-CRT import libs only. We deliberately do NOT add
+# the static libvcruntime.lib / libucrt.lib: on Windows SDK 10.0.26100 the
+# linker pulls msvcrt.lib's vcstartup DLL glue (utility.obj), which then
+# references the static __vcrt_initialize / __acrt_initialize helpers and
+# forces those static libs in. That links, but mixing the static CRT
+# startup with the dynamic CRT double-initialises the runtime and the
+# merged DLL crashes at load (0xc0000005). Windows SDK >= 10.0.28000 does
+# not pull utility.obj, so the dynamic-only link is both correct and
+# runtime-safe. The CI job installs that SDK; Get-SdkLibRoot prefers the
+# highest-versioned SDK present.
 #
 # An /machine:arm64x image has TWO symbol namespaces: a native ARM64 view
 # and an ARM64EC (x64-ABI) view. Each view must be satisfied by CRT libs
@@ -104,15 +100,7 @@ New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
 # errors. We therefore locate the ARM64 *and* x64 flavours of each lib via
 # the installed VS toolset + Windows SDK and pass them by full path, so the
 # link is self-contained and does not depend on LIB.
-$crtLibNames = @(
-    'kernel32.lib',
-    'msvcrt.lib',
-    'ucrt.lib',
-    'vcruntime.lib',
-    'libvcruntime.lib',
-    'libucrt.lib',
-    'uuid.lib'
-)
+$crtLibNames = @('kernel32.lib', 'msvcrt.lib', 'ucrt.lib', 'vcruntime.lib')
 
 # Resolve the VS MSVC tools lib root (…\VC\Tools\MSVC\<ver>\lib) and the
 # Windows SDK lib root (…\Lib\<ver>) for the current machine.
@@ -146,13 +134,21 @@ function Get-SdkLibRoot {
     if (-not $kitsRoot) { $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10' }
     $libBase = Join-Path $kitsRoot 'Lib'
     if (-not (Test-Path -LiteralPath $libBase)) { throw "Windows SDK Lib base not found at $libBase" }
+    # Windows SDK < 10.0.28000 makes the linker pull msvcrt.lib's utility.obj
+    # (vcstartup DLL glue), which forces the static CRT startup in and yields
+    # a merged DLL that crashes at load. Require >= 10.0.28000.
+    $minSdk = [version]'10.0.28000.0'
     # Highest-versioned SDK that ships both arm64 and x64 ucrt libs.
     $sdk = Get-ChildItem -LiteralPath $libBase -Directory |
         Where-Object { (Test-Path (Join-Path $_.FullName 'ucrt\arm64')) -and
-                       (Test-Path (Join-Path $_.FullName 'ucrt\x64')) } |
+                       (Test-Path (Join-Path $_.FullName 'ucrt\x64')) -and
+                       ([version]$_.Name -ge $minSdk) } |
         Sort-Object { [version]$_.Name } -Descending |
         Select-Object -First 1
-    if (-not $sdk) { throw "No Windows SDK with both arm64 and x64 ucrt libs under $libBase" }
+    if (-not $sdk) {
+        throw "No Windows SDK >= $minSdk (with arm64 + x64 ucrt libs) under $libBase. " +
+              "Install one, e.g. 'winget install --id Microsoft.WindowsSDK.10.0.28000 --source winget'."
+    }
     return $sdk.FullName
 }
 
@@ -163,16 +159,13 @@ Write-Host "==> Windows SDK lib root: $sdkLibRoot"
 
 # Map each bare CRT lib to its real location per architecture. The native
 # ARM64 view uses the arm64 libs; the ARM64EC view uses the x64 (x64-ABI)
-# libs. kernel32/uuid live under the SDK 'um' dir, ucrt/libucrt under the
-# SDK 'ucrt' dir, and msvcrt/vcruntime/libvcruntime under the MSVC tools
-# lib dir.
+# libs. kernel32 lives under the SDK 'um' dir, ucrt under the SDK 'ucrt'
+# dir, and msvcrt/vcruntime under the MSVC tools lib dir.
 function Resolve-CrtLib {
     param([string]$Name, [string]$Arch)
     switch ($Name) {
         'kernel32.lib' { $p = Join-Path $sdkLibRoot  "um\$Arch\$Name" }
-        'uuid.lib'     { $p = Join-Path $sdkLibRoot  "um\$Arch\$Name" }
         'ucrt.lib'     { $p = Join-Path $sdkLibRoot  "ucrt\$Arch\$Name" }
-        'libucrt.lib'  { $p = Join-Path $sdkLibRoot  "ucrt\$Arch\$Name" }
         default        { $p = Join-Path $msvcLibRoot "$Arch\$Name" }
     }
     if (-not (Test-Path -LiteralPath $p)) { throw "CRT lib not found: $p" }

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -72,14 +72,28 @@ $defArm64ec = Join-Path $OutDir 'rd_pipe.arm64ec.def'
 New-DefFromDll -Dll $Arm64Dll   -DefPath $defArm64
 New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
 
-# Minimum Windows SDK / CRT import libs needed for the link to succeed.
-# Determined empirically by drop-one probing against rust-lld 22.1.2:
-# - kernel32.lib  : __chkstk, _tls_index/_tls_used, baseline Win32
-# - msvcrt.lib    : _CxxThrowException, __CxxFrameHandler3 (ARM64EC)
-# - ucrt.lib      : memcpy/memset/memmove/memcmp, wcslen, etc.
-# - vcruntime.lib : softintrin / icall helpers (ARM64EC)
-# All other Win32 imports (advapi32, bcrypt, ntdll, ole32, oleaut32,
-# userenv, ws2_32, synchronization) are pulled in transitively via the
+# Windows SDK / CRT libs needed for the link to succeed:
+# - kernel32.lib     : __chkstk, _tls_index/_tls_used, baseline Win32
+# - msvcrt.lib       : dynamic-CRT import lib; _CxxThrowException,
+#                      __CxxFrameHandler3, and the vcstartup DLL glue
+#                      (utility.obj / _DllMainCRTStartup) that newer
+#                      toolchains pull in.
+# - ucrt.lib         : memcpy/memset/memmove/memcmp, wcslen, etc.
+# - vcruntime.lib    : softintrin / icall helpers (ARM64EC)
+# - libvcruntime.lib : STATIC vcruntime. Defines __vcrt_initialize and the
+#                      __vcrt_* thread attach/detach helpers that
+#                      msvcrt.lib(utility.obj) references but that the
+#                      *dynamic* import libs do not define.
+# - libucrt.lib      : STATIC UCRT. Defines __acrt_initialize,
+#                      _is_c_termination_complete and the __acrt_* helpers,
+#                      likewise referenced by the vcstartup glue.
+# - uuid.lib         : pulled via a /defaultlib directive emitted by the
+#                      libvcruntime objects.
+# msvcrt + the dynamic ucrt/vcruntime are listed before their static
+# counterparts so that, under /force:multiple, the dynamic CRT definitions
+# win and the static libs only supply the otherwise-undefined vcstartup
+# init helpers. All other Win32 imports (advapi32, bcrypt, ntdll, ole32,
+# oleaut32, userenv, ws2_32, synchronization) come in transitively via the
 # Rust staticlibs' raw_dylib stubs.
 #
 # An /machine:arm64x image has TWO symbol namespaces: a native ARM64 view
@@ -90,7 +104,15 @@ New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
 # errors. We therefore locate the ARM64 *and* x64 flavours of each lib via
 # the installed VS toolset + Windows SDK and pass them by full path, so the
 # link is self-contained and does not depend on LIB.
-$crtLibNames = @('kernel32.lib', 'msvcrt.lib', 'ucrt.lib', 'vcruntime.lib')
+$crtLibNames = @(
+    'kernel32.lib',
+    'msvcrt.lib',
+    'ucrt.lib',
+    'vcruntime.lib',
+    'libvcruntime.lib',
+    'libucrt.lib',
+    'uuid.lib'
+)
 
 # Resolve the VS MSVC tools lib root (…\VC\Tools\MSVC\<ver>\lib) and the
 # Windows SDK lib root (…\Lib\<ver>) for the current machine.
@@ -141,13 +163,16 @@ Write-Host "==> Windows SDK lib root: $sdkLibRoot"
 
 # Map each bare CRT lib to its real location per architecture. The native
 # ARM64 view uses the arm64 libs; the ARM64EC view uses the x64 (x64-ABI)
-# libs. kernel32 lives under the SDK 'um' dir, ucrt under 'ucrt', and
-# msvcrt/vcruntime under the MSVC tools lib dir.
+# libs. kernel32/uuid live under the SDK 'um' dir, ucrt/libucrt under the
+# SDK 'ucrt' dir, and msvcrt/vcruntime/libvcruntime under the MSVC tools
+# lib dir.
 function Resolve-CrtLib {
     param([string]$Name, [string]$Arch)
     switch ($Name) {
         'kernel32.lib' { $p = Join-Path $sdkLibRoot  "um\$Arch\$Name" }
+        'uuid.lib'     { $p = Join-Path $sdkLibRoot  "um\$Arch\$Name" }
         'ucrt.lib'     { $p = Join-Path $sdkLibRoot  "ucrt\$Arch\$Name" }
+        'libucrt.lib'  { $p = Join-Path $sdkLibRoot  "ucrt\$Arch\$Name" }
         default        { $p = Join-Path $msvcLibRoot "$Arch\$Name" }
     }
     if (-not (Test-Path -LiteralPath $p)) { throw "CRT lib not found: $p" }

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -81,12 +81,87 @@ New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
 # All other Win32 imports (advapi32, bcrypt, ntdll, ole32, oleaut32,
 # userenv, ws2_32, synchronization) are pulled in transitively via the
 # Rust staticlibs' raw_dylib stubs.
-$sdkLibs = @(
-    'kernel32.lib',
-    'msvcrt.lib',
-    'ucrt.lib',
-    'vcruntime.lib'
-)
+#
+# An /machine:arm64x image has TWO symbol namespaces: a native ARM64 view
+# and an ARM64EC (x64-ABI) view. Each view must be satisfied by CRT libs
+# of the matching architecture. Passing these by bare name only resolves
+# them from the ambient LIB env, which holds a single architecture, so one
+# view ends up with "undefined symbol ... (native symbol)" / "(EC symbol)"
+# errors. We therefore locate the ARM64 *and* x64 flavours of each lib via
+# the installed VS toolset + Windows SDK and pass them by full path, so the
+# link is self-contained and does not depend on LIB.
+$crtLibNames = @('kernel32.lib', 'msvcrt.lib', 'ucrt.lib', 'vcruntime.lib')
+
+# Resolve the VS MSVC tools lib root (…\VC\Tools\MSVC\<ver>\lib) and the
+# Windows SDK lib root (…\Lib\<ver>) for the current machine.
+function Get-MsvcLibRoot {
+    if ($env:VCToolsInstallDir) {
+        $r = Join-Path $env:VCToolsInstallDir 'lib'
+        if (Test-Path -LiteralPath $r) { return (Resolve-Path -LiteralPath $r).Path }
+    }
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path -LiteralPath $vswhere)) { throw "vswhere.exe not found at $vswhere" }
+    $vsRoot = (& $vswhere -latest -prerelease -products * `
+        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+        -property installationPath | Select-Object -First 1)
+    if (-not $vsRoot) { $vsRoot = (& $vswhere -latest -prerelease -products * -property installationPath | Select-Object -First 1) }
+    if (-not $vsRoot) { throw "No Visual Studio with VC tools found via vswhere" }
+    $verFile = Join-Path $vsRoot 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
+    if (-not (Test-Path -LiteralPath $verFile)) { throw "VC tools version file not found at $verFile" }
+    $ver = (Get-Content -LiteralPath $verFile -Raw).Trim()
+    $root = Join-Path $vsRoot "VC\Tools\MSVC\$ver\lib"
+    if (-not (Test-Path -LiteralPath $root)) { throw "MSVC lib root not found at $root" }
+    return $root
+}
+
+function Get-SdkLibRoot {
+    $kitsRoot = $null
+    foreach ($hive in 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0',
+                      'HKLM:\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0') {
+        $p = (Get-ItemProperty -Path $hive -Name 'KitsRoot10' -ErrorAction SilentlyContinue).KitsRoot10
+        if ($p) { $kitsRoot = $p; break }
+    }
+    if (-not $kitsRoot) { $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10' }
+    $libBase = Join-Path $kitsRoot 'Lib'
+    if (-not (Test-Path -LiteralPath $libBase)) { throw "Windows SDK Lib base not found at $libBase" }
+    # Highest-versioned SDK that ships both arm64 and x64 ucrt libs.
+    $sdk = Get-ChildItem -LiteralPath $libBase -Directory |
+        Where-Object { (Test-Path (Join-Path $_.FullName 'ucrt\arm64')) -and
+                       (Test-Path (Join-Path $_.FullName 'ucrt\x64')) } |
+        Sort-Object { [version]$_.Name } -Descending |
+        Select-Object -First 1
+    if (-not $sdk) { throw "No Windows SDK with both arm64 and x64 ucrt libs under $libBase" }
+    return $sdk.FullName
+}
+
+$msvcLibRoot = Get-MsvcLibRoot
+$sdkLibRoot = Get-SdkLibRoot
+Write-Host "==> MSVC lib root: $msvcLibRoot"
+Write-Host "==> Windows SDK lib root: $sdkLibRoot"
+
+# Map each bare CRT lib to its real location per architecture. The native
+# ARM64 view uses the arm64 libs; the ARM64EC view uses the x64 (x64-ABI)
+# libs. kernel32 lives under the SDK 'um' dir, ucrt under 'ucrt', and
+# msvcrt/vcruntime under the MSVC tools lib dir.
+function Resolve-CrtLib {
+    param([string]$Name, [string]$Arch)
+    switch ($Name) {
+        'kernel32.lib' { $p = Join-Path $sdkLibRoot  "um\$Arch\$Name" }
+        'ucrt.lib'     { $p = Join-Path $sdkLibRoot  "ucrt\$Arch\$Name" }
+        default        { $p = Join-Path $msvcLibRoot "$Arch\$Name" }
+    }
+    if (-not (Test-Path -LiteralPath $p)) { throw "CRT lib not found: $p" }
+    return $p
+}
+
+$sdkLibs = @()
+foreach ($arch in 'arm64', 'x64') {
+    foreach ($name in $crtLibNames) {
+        $sdkLibs += (Resolve-CrtLib -Name $name -Arch $arch)
+    }
+}
+Write-Host "==> CRT libs (arm64 native + x64 EC):"
+$sdkLibs | ForEach-Object { Write-Host "    $_" }
 
 $outDll = Join-Path $OutDir 'rd_pipe.dll'
 

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -7,11 +7,16 @@
 #   -Arm64ecDll : path to target\arm64ec-pc-windows-msvc\release\rd_pipe.dll
 #   -OutDir     : directory to place the merged rd_pipe.dll
 #
-# Final link uses /MACHINE:ARM64X via rust-lld from the active rustc
-# toolchain. Explicit Windows SDK import libs are passed because Rust
-# staticlibs do not embed them; they reference SDK symbols via
-# raw_dylib stubs that the ARM64X linker cannot resolve without proper
-# import libraries.
+# Final link uses /MACHINE:ARM64X via MSVC link.exe (discovered from the
+# active VS installation via vswhere), which handles the ARM64X TLS directory
+# correctly. lld-link is NOT used because it corrupts the EC view's TLS
+# (_tls_used/_tls_index/TLS-callback directory) when merging two full Rust
+# staticlibs.
+#
+# Import libs are passed explicitly by full path for both the ARM64 (native)
+# and x64 (EC) views because an /machine:arm64x link needs import libraries
+# for both architectures. Bare lib names resolved from ambient LIB only cover
+# one architecture.
 #
 # DEF files are generated on the fly from the per-arch DLLs via
 # llvm-readobj --coff-exports so the merged binary's export table is the
@@ -30,83 +35,48 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Resolve rust-lld + llvm-readobj bundled with the active rustc toolchain.
-# llvm-readobj requires the `llvm-tools` rustup component.
+# Resolve llvm-readobj bundled with the active rustc toolchain.
+# Requires the `llvm-tools` rustup component.
 $sysroot = (& rustc --print sysroot).Trim()
 $hostTriple = (& rustc -vV | Select-String '^host:').ToString().Split(' ', 2)[1].Trim()
 $rustlibBin = Join-Path $sysroot "lib\rustlib\$hostTriple\bin"
-$linkExe = Join-Path $rustlibBin 'gcc-ld\lld-link.exe'
 $readobjExe = Join-Path $rustlibBin 'llvm-readobj.exe'
-if (-not (Test-Path -LiteralPath $linkExe)) {
-    throw "rust-lld not found at $linkExe"
-}
 if (-not (Test-Path -LiteralPath $readobjExe)) {
     throw "llvm-readobj not found at $readobjExe (install rustup component 'llvm-tools')"
 }
 
-New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
-
-# Generate a DEF file from a per-arch DLL via `llvm-readobj --coff-exports`.
-# Output format:
-#   Export {
-#     Ordinal: <n>
-#     Name: <symbol>
-#     RVA: 0x<hex>
-#   }
-# We extract every `Name:` line. Order doesn't matter for /def.
-function New-DefFromDll {
-    param([string]$Dll, [string]$DefPath)
-    $names = & $readobjExe --coff-exports $Dll |
-        Select-String '^\s*Name: (\S+)$' |
-        ForEach-Object { $_.Matches[0].Groups[1].Value }
-    if (-not $names) {
-        throw "No exports found in $Dll via $readobjExe"
+# Resolve MSVC link.exe. We prefer the ARM64-hosted linker so the process
+# itself runs natively; fall back to x64-hosted which works under WOW64.
+# Uses VCToolsInstallDir env (set by vcvars) or falls back to vswhere.
+function Get-MsvcLinkExe {
+    $vcRoot = $null
+    if ($env:VCToolsInstallDir) {
+        $vcRoot = $env:VCToolsInstallDir.TrimEnd('\/')
+    } else {
+        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+        if (-not (Test-Path -LiteralPath $vswhere)) { throw "vswhere.exe not found at $vswhere" }
+        $vsRoot = (& $vswhere -latest -prerelease -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath | Select-Object -First 1)
+        if (-not $vsRoot) { $vsRoot = (& $vswhere -latest -prerelease -products * -property installationPath | Select-Object -First 1) }
+        if (-not $vsRoot) { throw "No Visual Studio with VC tools found via vswhere" }
+        $verFile = Join-Path $vsRoot 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
+        if (-not (Test-Path -LiteralPath $verFile)) { throw "VC tools version file not found at $verFile" }
+        $ver = (Get-Content -LiteralPath $verFile -Raw).Trim()
+        $vcRoot = Join-Path $vsRoot "VC\Tools\MSVC\$ver"
     }
-    $lines = @('EXPORTS') + ($names | ForEach-Object { "    $_" })
-    Set-Content -Path $DefPath -Value $lines -Encoding ASCII
-    Write-Host "==> Generated $DefPath ($($names.Count) exports): $($names -join ', ')"
+    foreach ($hostDir in 'Hostarm64\arm64', 'HostARM64\arm64', 'Hostx64\x64') {
+        $p = Join-Path $vcRoot "bin\$hostDir\link.exe"
+        if (Test-Path -LiteralPath $p) { return $p }
+    }
+    throw "MSVC link.exe not found under $vcRoot\bin"
 }
 
-$defArm64 = Join-Path $OutDir 'rd_pipe.arm64.def'
-$defArm64ec = Join-Path $OutDir 'rd_pipe.arm64ec.def'
-New-DefFromDll -Dll $Arm64Dll   -DefPath $defArm64
-New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
-
-# Windows SDK / CRT import libs needed for the link to succeed:
-# - kernel32.lib  : __chkstk, _tls_index/_tls_used, baseline Win32
-# - msvcrt.lib    : _CxxThrowException, __CxxFrameHandler3 (ARM64EC)
-# - ucrt.lib      : memcpy/memset/memmove/memcmp, wcslen, etc.
-# - vcruntime.lib : softintrin / icall helpers (ARM64EC)
-# All other Win32 imports (advapi32, bcrypt, ntdll, ole32, oleaut32,
-# userenv, ws2_32, synchronization) are pulled in transitively via the
-# Rust staticlibs' raw_dylib stubs.
-#
-# These are the DYNAMIC-CRT import libs only. We deliberately do NOT add
-# the static libvcruntime.lib / libucrt.lib: on Windows SDK 10.0.26100 the
-# linker pulls msvcrt.lib's vcstartup DLL glue (utility.obj), which then
-# references the static __vcrt_initialize / __acrt_initialize helpers and
-# forces those static libs in. That links, but mixing the static CRT
-# startup with the dynamic CRT double-initialises the runtime and the
-# merged DLL crashes at load (0xc0000005). Windows SDK >= 10.0.28000 does
-# not pull utility.obj, so the dynamic-only link is both correct and
-# runtime-safe. The CI job installs that SDK; Get-SdkLibRoot prefers the
-# highest-versioned SDK present.
-#
-# An /machine:arm64x image has TWO symbol namespaces: a native ARM64 view
-# and an ARM64EC (x64-ABI) view. Each view must be satisfied by CRT libs
-# of the matching architecture. Passing these by bare name only resolves
-# them from the ambient LIB env, which holds a single architecture, so one
-# view ends up with "undefined symbol ... (native symbol)" / "(EC symbol)"
-# errors. We therefore locate the ARM64 *and* x64 flavours of each lib via
-# the installed VS toolset + Windows SDK and pass them by full path, so the
-# link is self-contained and does not depend on LIB.
-$crtLibNames = @('kernel32.lib', 'msvcrt.lib', 'ucrt.lib', 'vcruntime.lib')
-
-# Resolve the VS MSVC tools lib root (…\VC\Tools\MSVC\<ver>\lib) and the
-# Windows SDK lib root (…\Lib\<ver>) for the current machine.
 function Get-MsvcLibRoot {
+    $vcRoot = $null
     if ($env:VCToolsInstallDir) {
-        $r = Join-Path $env:VCToolsInstallDir 'lib'
+        $vcRoot = $env:VCToolsInstallDir.TrimEnd('\/')
+        $r = Join-Path $vcRoot 'lib'
         if (Test-Path -LiteralPath $r) { return (Resolve-Path -LiteralPath $r).Path }
     }
     $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
@@ -134,75 +104,171 @@ function Get-SdkLibRoot {
     if (-not $kitsRoot) { $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10' }
     $libBase = Join-Path $kitsRoot 'Lib'
     if (-not (Test-Path -LiteralPath $libBase)) { throw "Windows SDK Lib base not found at $libBase" }
-    # Windows SDK < 10.0.28000 makes the linker pull msvcrt.lib's utility.obj
-    # (vcstartup DLL glue), which forces the static CRT startup in and yields
-    # a merged DLL that crashes at load. Require >= 10.0.28000.
-    $minSdk = [version]'10.0.28000.0'
-    # Highest-versioned SDK that ships both arm64 and x64 ucrt libs.
+    # Pick the highest-versioned SDK that ships both arm64 and x64 ucrt/um libs.
     $sdk = Get-ChildItem -LiteralPath $libBase -Directory |
-        Where-Object { (Test-Path (Join-Path $_.FullName 'ucrt\arm64')) -and
-                       (Test-Path (Join-Path $_.FullName 'ucrt\x64')) -and
-                       ([version]$_.Name -ge $minSdk) } |
+        Where-Object { (Test-Path (Join-Path $_.FullName 'um\arm64')) -and
+                       (Test-Path (Join-Path $_.FullName 'um\x64')) } |
         Sort-Object { [version]$_.Name } -Descending |
         Select-Object -First 1
     if (-not $sdk) {
-        throw "No Windows SDK >= $minSdk (with arm64 + x64 ucrt libs) under $libBase. " +
-              "Install one, e.g. 'winget install --id Microsoft.WindowsSDK.10.0.28000 --source winget'."
+        throw "No Windows SDK with arm64 + x64 um libs found under $libBase."
     }
     return $sdk.FullName
 }
 
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+$linkExe    = Get-MsvcLinkExe
 $msvcLibRoot = Get-MsvcLibRoot
-$sdkLibRoot = Get-SdkLibRoot
-Write-Host "==> MSVC lib root: $msvcLibRoot"
-Write-Host "==> Windows SDK lib root: $sdkLibRoot"
+$sdkLibRoot  = Get-SdkLibRoot
 
-# Map each bare CRT lib to its real location per architecture. The native
-# ARM64 view uses the arm64 libs; the ARM64EC view uses the x64 (x64-ABI)
-# libs. kernel32 lives under the SDK 'um' dir, ucrt under the SDK 'ucrt'
-# dir, and msvcrt/vcruntime under the MSVC tools lib dir.
-function Resolve-CrtLib {
-    param([string]$Name, [string]$Arch)
-    switch ($Name) {
-        'kernel32.lib' { $p = Join-Path $sdkLibRoot  "um\$Arch\$Name" }
-        'ucrt.lib'     { $p = Join-Path $sdkLibRoot  "ucrt\$Arch\$Name" }
-        default        { $p = Join-Path $msvcLibRoot "$Arch\$Name" }
+Write-Host "==> MSVC link.exe:    $linkExe"
+Write-Host "==> MSVC lib root:    $msvcLibRoot"
+Write-Host "==> Windows SDK root: $sdkLibRoot"
+
+# Generate a DEF file from a per-arch DLL via `llvm-readobj --coff-exports`.
+function New-DefFromDll {
+    param([string]$Dll, [string]$DefPath)
+    $names = & $readobjExe --coff-exports $Dll |
+        Select-String '^\s*Name: (\S+)$' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value }
+    if (-not $names) {
+        throw "No exports found in $Dll via $readobjExe"
     }
-    if (-not (Test-Path -LiteralPath $p)) { throw "CRT lib not found: $p" }
-    return $p
+    $lines = @('EXPORTS') + ($names | ForEach-Object { "    $_" })
+    Set-Content -Path $DefPath -Value $lines -Encoding ASCII
+    Write-Host "==> Generated $DefPath ($($names.Count) exports): $($names -join ', ')"
 }
 
-$sdkLibs = @()
-foreach ($arch in 'arm64', 'x64') {
-    foreach ($name in $crtLibNames) {
-        $sdkLibs += (Resolve-CrtLib -Name $name -Arch $arch)
+$defArm64   = Join-Path $OutDir 'rd_pipe.arm64.def'
+$defArm64ec = Join-Path $OutDir 'rd_pipe.arm64ec.def'
+New-DefFromDll -Dll $Arm64Dll   -DefPath $defArm64
+New-DefFromDll -Dll $Arm64ecDll -DefPath $defArm64ec
+
+# Import libs needed for the /machine:arm64x link.
+# Mirror exactly what rustc passes for each architecture (from `cargo rustc -- --print link-args`):
+#   ARM64 (native view): kernel32 ntdll userenv ws2_32 dbghelp  + /defaultlib:msvcrt
+#   ARM64EC (EC view):   kernel32 ntdll userenv ws2_32 dbghelp  + /defaultlib:msvcrt + softintrin
+#
+# An ARM64X link has TWO symbol namespaces; we need CRT + SDK libs for BOTH:
+#   - MSVC arm64\ for both views (msvcrt, vcruntime, ucrt-style helpers)
+#   - SDK ucrt\arm64  for the native view
+#   - SDK ucrt\arm64ec (or x64 fallback) for the EC view
+#   - SDK um\arm64    for the native view
+#   - SDK um\arm64ec  (or x64 fallback) for the EC view
+#   - softintrin (EC/arm64ec only)
+#
+# Note: __icall_helper_arm64ec lives in arm64\msvcrt.lib (not x64 or arm64ec).
+# Note: SDK 10.0.28000 does not have a um\arm64ec dir; fall back to um\x64.
+function Resolve-LibForView {
+    param([string]$Name, [string]$Arch)  # Arch = 'arm64' | 'arm64ec'
+    # CRT libs from MSVC: always use arm64 dir (same helpers serve both views)
+    if ($Name -match '^(msvcrt|vcruntime)\.lib$') {
+        $p = Join-Path $msvcLibRoot "arm64\$Name"
+        if (-not (Test-Path -LiteralPath $p)) { throw "MSVC lib not found: $p" }
+        return $p
     }
+    # SDK ucrt
+    if ($Name -match '^ucrt\.lib$') {
+        foreach ($a in $Arch, 'x64') {
+            $p = Join-Path $sdkLibRoot "ucrt\$a\$Name"
+            if (Test-Path -LiteralPath $p) { return $p }
+        }
+        throw "ucrt.lib not found for arch $Arch"
+    }
+    # SDK um libs (kernel32, ntdll, etc.)
+    foreach ($a in $Arch, 'x64', 'arm64') {
+        $dir = Join-Path $sdkLibRoot "um\$a"
+        if (Test-Path -LiteralPath $dir) {
+            $found = Get-ChildItem $dir -Filter $Name -ErrorAction SilentlyContinue |
+                Select-Object -First 1 -ExpandProperty FullName
+            if ($found) { return $found }
+        }
+    }
+    throw "SDK um lib $Name not found for arch $Arch"
 }
-Write-Host "==> CRT libs (arm64 native + x64 EC):"
-$sdkLibs | ForEach-Object { Write-Host "    $_" }
+
+$crtLibNames = @('vcruntime.lib')
+$umLibNames  = @('kernel32.Lib', 'ntdll.lib', 'UserEnv.Lib', 'WS2_32.Lib', 'DbgHelp.Lib')
+
+$importLibs = @()
+foreach ($name in ($crtLibNames + $umLibNames)) {
+    $importLibs += (Resolve-LibForView -Name $name -Arch 'arm64')
+}
+foreach ($name in ($crtLibNames + $umLibNames)) {
+    $importLibs += (Resolve-LibForView -Name $name -Arch 'arm64ec')
+}
+# softintrin is EC (arm64ec/x64-ABI) only - SDK um x64
+$softintrin = Join-Path $sdkLibRoot 'um\x64\softintrin.lib'
+if (-not (Test-Path -LiteralPath $softintrin)) {
+    $softintrin = Join-Path $sdkLibRoot 'um\arm64\softintrin.lib'
+    if (-not (Test-Path -LiteralPath $softintrin)) { throw "softintrin.lib not found" }
+}
+$importLibs += $softintrin
+
+# arm64\msvcrt.lib provides __icall_helper_arm64ec (needed by EC raw_dylib stubs)
+# but also contains dll_dllmain_stub.obj which would override our DllMain if passed
+# as an explicit input. Pass it via /DEFAULTLIB: so it is lower priority than the
+# explicit staticlibs: our DllMain objects from rd_pipe.lib win, dll_dllmain_stub
+# becomes the second definition (ignored by /force:multiple).
+$msvcrtArm64Lib  = Join-Path $msvcLibRoot 'arm64\msvcrt.lib'
+$msvcrtX64Lib    = Join-Path $msvcLibRoot 'x64\msvcrt.lib'
+if (-not (Test-Path -LiteralPath $msvcrtArm64Lib)) { throw "arm64\msvcrt.lib not found at $msvcrtArm64Lib" }
+if (-not (Test-Path -LiteralPath $msvcrtX64Lib))   { throw "x64\msvcrt.lib not found at $msvcrtX64Lib" }
+
+Write-Host "==> Import libs (arm64 native + arm64ec EC):"
+$importLibs | ForEach-Object { Write-Host "    $_" }
 
 $outDll = Join-Path $OutDir 'rd_pipe.dll'
 
-Write-Host "==> Linking ARM64X merged DLL with $linkExe"
-# /entry:DllMain ensures the loader calls our Rust DllMain rather than the
-# msvcrt stub (msvcrt provides a no-op _DllMainCRTStartup; we want our own).
-# /force:multiple resolves the resulting duplicate-symbol diagnostic in
-# favor of the input listed first (the Rust staticlibs).
+Write-Host "==> Linking ARM64X merged DLL with MSVC link.exe"
 # /defArm64Native + /def supply the export tables for the ARM64 native and
 # ARM64EC views respectively. Each DEF is generated from the matching
 # per-arch DLL so the merged binary exposes the exact union of exports
 # rustc emitted for each arch.
+#
+# /force:multiple: resolves duplicate DllMain symbols. The merged link has two
+# DllMain definitions: one from each per-arch staticlib AND a stub from
+# msvcrt.lib(dll_dllmain_stub.obj). The stub wins via /force:multiple but that
+# is intentional: the stub is the CRT-wrapped DllMain — it calls
+# dllmain_crt_process_attach which chains through _pRawDllMain to user code.
+# Our actual DllMain (tracing init + Tokio runtime) runs via _pRawDllMain.
+#
+# arm64\msvcrt.lib is passed after the staticlibs via /NODEFAULTLIB + explicit
+# path so the linker sees our DllMain objects before the stub. msvcrt.lib is
+# still needed as an explicit input because arm64\msvcrt.lib provides
+# __icall_helper_arm64ec (used by the EC view's raw_dylib import stubs) and
+# arm64\vcruntime.lib provides __CxxFrameHandler3/__chkstk.
+#
+# /LIBPATH: dirs allow the .drectve /defaultlib:... entries baked into the
+# staticlibs to resolve without vcvars being active.
+$libpathMsvcArm64  = Join-Path $msvcLibRoot 'arm64'
+$libpathMsvcX64    = Join-Path $msvcLibRoot 'x64'
+$libpathUcrtArm64  = Join-Path $sdkLibRoot 'ucrt\arm64'
+$libpathUcrtArm64ec= Join-Path $sdkLibRoot 'ucrt\arm64ec'
+$libpathUcrtX64    = Join-Path $sdkLibRoot 'ucrt\x64'
+$libpathUmArm64    = Join-Path $sdkLibRoot 'um\arm64'
+$libpathUmX64      = Join-Path $sdkLibRoot 'um\x64'
+
 & $linkExe `
     /dll /machine:arm64x /nologo `
     /noimplib `
-    /entry:DllMain `
     /force:multiple `
+    "/NODEFAULTLIB:msvcrt" `
+    "/LIBPATH:$libpathMsvcArm64" `
+    "/LIBPATH:$libpathMsvcX64" `
+    "/LIBPATH:$libpathUcrtArm64" `
+    "/LIBPATH:$libpathUcrtArm64ec" `
+    "/LIBPATH:$libpathUcrtX64" `
+    "/LIBPATH:$libpathUmArm64" `
+    "/LIBPATH:$libpathUmX64" `
     "/defArm64Native:$defArm64" `
     "/def:$defArm64ec" `
     "/out:$outDll" `
     $Arm64Lib $Arm64ecLib `
-    @sdkLibs
-if ($LASTEXITCODE -ne 0) { throw "rust-lld failed" }
+    @importLibs `
+    $msvcrtArm64Lib $msvcrtX64Lib
+if ($LASTEXITCODE -ne 0) { throw "MSVC link.exe failed with exit code $LASTEXITCODE" }
 
 Write-Host "==> Merged ARM64X DLL built: $outDll"
 Get-Item $outDll | Format-List FullName, Length, LastWriteTime

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -19,10 +19,10 @@
 # one architecture.
 #
 # DEF files are generated on the fly from the per-arch DLLs via
-# llvm-readobj --coff-exports so the merged binary's export table is the
-# exact union of the per-arch tables (DllMain, DllGetClassObject,
-# DllInstall, plus anything Rust adds in the future). Avoids drift
-# between a hand-maintained DEF and what rustc actually exports.
+# `dumpbin /exports` (same VS install, no extra components needed) so the
+# merged binary's export table is the exact union of the per-arch tables
+# (DllMain, DllGetClassObject, DllInstall, plus anything Rust adds in the
+# future). Avoids drift between a hand-maintained DEF and what rustc exports.
 
 [CmdletBinding()]
 param(
@@ -35,20 +35,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Resolve llvm-readobj bundled with the active rustc toolchain.
-# Requires the `llvm-tools` rustup component.
-$sysroot = (& rustc --print sysroot).Trim()
-$hostTriple = (& rustc -vV | Select-String '^host:').ToString().Split(' ', 2)[1].Trim()
-$rustlibBin = Join-Path $sysroot "lib\rustlib\$hostTriple\bin"
-$readobjExe = Join-Path $rustlibBin 'llvm-readobj.exe'
-if (-not (Test-Path -LiteralPath $readobjExe)) {
-    throw "llvm-readobj not found at $readobjExe (install rustup component 'llvm-tools')"
-}
-
-# Resolve MSVC link.exe. We prefer the ARM64-hosted linker so the process
-# itself runs natively; fall back to x64-hosted which works under WOW64.
-# Uses VCToolsInstallDir env (set by vcvars) or falls back to vswhere.
-function Get-MsvcLinkExe {
+# Resolve MSVC link.exe and dumpbin.exe. Both come from the same VS VC tools
+# install — no extra rustup components required.
+# Prefers ARM64-hosted binaries (run natively); falls back to x64-hosted.
+# Uses VCToolsInstallDir env (set by vcvars) or discovers via vswhere.
+function Get-MsvcTool {
+    param([string]$Name)
     $vcRoot = $null
     if ($env:VCToolsInstallDir) {
         $vcRoot = $env:VCToolsInstallDir.TrimEnd('\/')
@@ -66,30 +58,23 @@ function Get-MsvcLinkExe {
         $vcRoot = Join-Path $vsRoot "VC\Tools\MSVC\$ver"
     }
     foreach ($hostDir in 'Hostarm64\arm64', 'HostARM64\arm64', 'Hostx64\x64') {
-        $p = Join-Path $vcRoot "bin\$hostDir\link.exe"
+        $p = Join-Path $vcRoot "bin\$hostDir\$Name"
         if (Test-Path -LiteralPath $p) { return $p }
     }
-    throw "MSVC link.exe not found under $vcRoot\bin"
+    throw "MSVC $Name not found under $vcRoot\bin"
 }
 
 function Get-MsvcLibRoot {
-    $vcRoot = $null
+    # Derive lib root from VCToolsInstallDir or the same vswhere path Get-MsvcTool uses.
     if ($env:VCToolsInstallDir) {
-        $vcRoot = $env:VCToolsInstallDir.TrimEnd('\/')
-        $r = Join-Path $vcRoot 'lib'
+        $r = Join-Path $env:VCToolsInstallDir.TrimEnd('\/') 'lib'
         if (Test-Path -LiteralPath $r) { return (Resolve-Path -LiteralPath $r).Path }
     }
-    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-    if (-not (Test-Path -LiteralPath $vswhere)) { throw "vswhere.exe not found at $vswhere" }
-    $vsRoot = (& $vswhere -latest -prerelease -products * `
-        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-        -property installationPath | Select-Object -First 1)
-    if (-not $vsRoot) { $vsRoot = (& $vswhere -latest -prerelease -products * -property installationPath | Select-Object -First 1) }
-    if (-not $vsRoot) { throw "No Visual Studio with VC tools found via vswhere" }
-    $verFile = Join-Path $vsRoot 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
-    if (-not (Test-Path -LiteralPath $verFile)) { throw "VC tools version file not found at $verFile" }
-    $ver = (Get-Content -LiteralPath $verFile -Raw).Trim()
-    $root = Join-Path $vsRoot "VC\Tools\MSVC\$ver\lib"
+    # Get-MsvcTool already validated the VS install; re-derive the lib path from it.
+    $linkExePath = Get-MsvcTool 'link.exe'   # e.g. ...\bin\Hostarm64\arm64\link.exe
+    # Strip \arm64, \Hostarm64, \bin to reach the MSVC version root
+    $vcVersionRoot = Split-Path (Split-Path (Split-Path (Split-Path $linkExePath)))
+    $root = Join-Path $vcVersionRoot 'lib'
     if (-not (Test-Path -LiteralPath $root)) { throw "MSVC lib root not found at $root" }
     return $root
 }
@@ -118,22 +103,27 @@ function Get-SdkLibRoot {
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
-$linkExe    = Get-MsvcLinkExe
+$linkExe     = Get-MsvcTool 'link.exe'
+$dumpbinExe  = Get-MsvcTool 'dumpbin.exe'
 $msvcLibRoot = Get-MsvcLibRoot
 $sdkLibRoot  = Get-SdkLibRoot
 
 Write-Host "==> MSVC link.exe:    $linkExe"
+Write-Host "==> MSVC dumpbin.exe: $dumpbinExe"
 Write-Host "==> MSVC lib root:    $msvcLibRoot"
 Write-Host "==> Windows SDK root: $sdkLibRoot"
 
-# Generate a DEF file from a per-arch DLL via `llvm-readobj --coff-exports`.
+# Generate a DEF file from a per-arch DLL via `dumpbin /exports`.
+# Output format includes lines like:
+#   <ordinal>  <hint>  <RVA>  <name>
+# We match the name in the 4th field of export lines.
 function New-DefFromDll {
     param([string]$Dll, [string]$DefPath)
-    $names = & $readobjExe --coff-exports $Dll |
-        Select-String '^\s*Name: (\S+)$' |
+    $names = & $dumpbinExe /exports $Dll 2>&1 |
+        Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
         ForEach-Object { $_.Matches[0].Groups[1].Value }
     if (-not $names) {
-        throw "No exports found in $Dll via $readobjExe"
+        throw "No exports found in $Dll via $dumpbinExe"
     }
     $lines = @('EXPORTS') + ($names | ForEach-Object { "    $_" })
     Set-Content -Path $DefPath -Value $lines -Encoding ASCII

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -9,10 +9,14 @@
 #
 # Requires a VS Developer Command Prompt environment (vcvarsall arm64 or the
 # ilammy/msvc-dev-cmd action with arch:arm64). This sets:
-#   PATH              -> link.exe, dumpbin.exe
-#   VCToolsInstallDir -> MSVC lib root
+#   VCToolsInstallDir -> MSVC tool + lib root
 #   WindowsSdkDir + WindowsSDKVersion -> SDK lib root
 #   LIB               -> arm64 MSVC + arm64 ucrt + arm64 um (native view)
+#
+# link.exe and dumpbin.exe are resolved directly from VCToolsInstallDir\bin\HostX64\x64
+# to avoid two PATH hazards on GitHub-hosted Windows runners:
+#   - vcvarsall x64_arm64 only prepends HostX64\arm64, leaving dumpbin off PATH.
+#   - Git for Windows ships usr\bin\link.exe (a Unix tool) before MSVC on PATH.
 #
 # Uses MSVC link.exe (/machine:arm64x). lld-link is NOT used: it corrupts the
 # EC view's TLS directory when merging two Rust staticlibs into one ARM64X image.
@@ -43,16 +47,26 @@ $sdkLib  = Join-Path $env:WindowsSdkDir.TrimEnd('\/') "Lib\$($env:WindowsSDKVers
 Write-Host "==> MSVC lib root:    $msvcLib"
 Write-Host "==> Windows SDK root: $sdkLib"
 
-# dumpbin.exe lives in Hostx64\x64 — not always on PATH when vcvars is set up
-# for a cross-compilation target (e.g. vcvarsall x64_arm64 only prepends Hostx64\arm64).
-$dumpbinExe = (Get-Command dumpbin -ErrorAction SilentlyContinue)?.Source
-if (-not $dumpbinExe) {
-    $dumpbinExe = Join-Path $env:VCToolsInstallDir "bin\HostX64\x64\dumpbin.exe"
-    if (-not (Test-Path $dumpbinExe)) {
-        throw "dumpbin.exe not found on PATH or at $dumpbinExe"
-    }
-    Write-Host "==> dumpbin: $dumpbinExe (resolved via VCToolsInstallDir)"
+# dumpbin.exe and link.exe must be resolved via VCToolsInstallDir rather than
+# relying on PATH. Two PATH hazards on GitHub-hosted runners:
+#
+#   1. vcvarsall x64_arm64 (ilammy/msvc-dev-cmd arch:arm64) prepends
+#      HostX64\arm64 but NOT HostX64\x64, so dumpbin.exe is missing from PATH.
+#
+#   2. Git for Windows ships C:\Program Files\Git\usr\bin\link.exe (a Unix
+#      hard-link tool) earlier on PATH than any MSVC entry, so bare "link.exe"
+#      resolves to the wrong binary.
+#
+# HostX64\x64\{dumpbin,link}.exe is always present for an x64 VS install and
+# supports all /machine targets including arm64x.
+$vcBinX64   = Join-Path $env:VCToolsInstallDir "bin\HostX64\x64"
+$dumpbinExe = Join-Path $vcBinX64 "dumpbin.exe"
+$linkExe    = Join-Path $vcBinX64 "link.exe"
+foreach ($exe in $dumpbinExe, $linkExe) {
+    if (-not (Test-Path $exe)) { throw "$exe not found — check VCToolsInstallDir" }
 }
+Write-Host "==> dumpbin: $dumpbinExe"
+Write-Host "==> link:    $linkExe"
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
@@ -110,7 +124,7 @@ $msvcrtLib = "$msvcLib\arm64\msvcrt.lib"
 $outDll = Join-Path $OutDir 'rd_pipe.dll'
 
 Write-Host "==> Linking ARM64X DLL..."
-link.exe `
+& $linkExe `
     /dll /machine:arm64x /nologo /noimplib /force:multiple `
     "/NODEFAULTLIB:msvcrt" `
     "/LIBPATH:$msvcLib\arm64" `

--- a/arm64x/build_merged.ps1
+++ b/arm64x/build_merged.ps1
@@ -43,12 +43,23 @@ $sdkLib  = Join-Path $env:WindowsSdkDir.TrimEnd('\/') "Lib\$($env:WindowsSDKVers
 Write-Host "==> MSVC lib root:    $msvcLib"
 Write-Host "==> Windows SDK root: $sdkLib"
 
+# dumpbin.exe lives in Hostx64\x64 — not always on PATH when vcvars is set up
+# for a cross-compilation target (e.g. vcvarsall x64_arm64 only prepends Hostx64\arm64).
+$dumpbinExe = (Get-Command dumpbin -ErrorAction SilentlyContinue)?.Source
+if (-not $dumpbinExe) {
+    $dumpbinExe = Join-Path $env:VCToolsInstallDir "bin\HostX64\x64\dumpbin.exe"
+    if (-not (Test-Path $dumpbinExe)) {
+        throw "dumpbin.exe not found on PATH or at $dumpbinExe"
+    }
+    Write-Host "==> dumpbin: $dumpbinExe (resolved via VCToolsInstallDir)"
+}
+
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
 # Generate a DEF file from a per-arch DLL via dumpbin /exports.
 function New-DefFromDll {
     param([string]$Dll, [string]$DefPath)
-    $names = dumpbin /exports $Dll 2>&1 |
+    $names = & $dumpbinExe /exports $Dll 2>&1 |
         Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
         ForEach-Object { $_.Matches[0].Groups[1].Value }
     if (-not $names) { throw "No exports found in $Dll" }


### PR DESCRIPTION
This pull request updates the CI workflow to use the nightly Rust toolchain instead of stable, and introduces a new self-hosted runner label configuration. The main focus is on ensuring that all CI jobs use the nightly toolchain, which may be necessary for newer features or compatibility reasons.

**CI workflow updates:**

* Switched the Rust toolchain from `stable` to `nightly` in all relevant CI jobs within `.github/workflows/ci.yml`, affecting formatting checks, builds, and target-specific jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL31-R31) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL75-R75) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL131-R131) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL182-R182)

**Runner configuration:**

* Added a new self-hosted runner label `windows-11-arm` to `.github/actionlint.yaml` for improved runner selection and configuration.